### PR TITLE
Parse query parameters in JSON() binding

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/gorilla/schema"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/unknwon/com"
 )
@@ -167,16 +169,33 @@ func MultipartForm(req *http.Request, formStruct interface{}) Errors {
 // validated, but no error handling is actually performed here.
 // An interface pointer can be added as a second argument in order
 // to map the struct to a specific interface.
+//
+// For all requests, Json parses the raw query from the URL using matching struct json tags.
+//
+// For POST, PUT, and PATCH requests, it also parses the request body.
+// Request body parameters take precedence over URL query string values.
+//
+// Json follows the Request.ParseForm() method from Go's net/http library.
+// ref: https://github.com/golang/go/blob/700e969d5b23732179ea86cfe67e8d1a0a1cc10a/src/net/http/request.go#L1176
 func JSON(req *http.Request, jsonStruct interface{}) Errors {
 	var errors Errors
 	ensurePointer(jsonStruct)
 
-	if req.Body != nil {
-		defer req.Body.Close()
-		err := json.NewDecoder(req.Body).Decode(jsonStruct)
-		if err != nil && err != io.EOF {
-			errors.Add([]string{}, ERR_DESERIALIZATION, err.Error())
+	var err error
+	if req.URL != nil {
+		if params := req.URL.Query(); len(params) > 0 {
+			d := schema.NewDecoder()
+			d.SetAliasTag("json")
+			err = d.Decode(jsonStruct, params)
 		}
+	}
+	if req.Method == http.MethodPost || req.Method == http.MethodPut || req.Method == http.MethodPatch {
+		if req.Body != nil && (err == nil || err == io.EOF) {
+			err = json.NewDecoder(req.Body).Decode(jsonStruct)
+		}
+	}
+	if err != nil && err != io.EOF {
+		errors.Add([]string{}, ERR_DESERIALIZATION, err.Error())
 	}
 	return append(errors, Validate(req, jsonStruct)...)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/go-chi/chi v1.5.1
+	github.com/gorilla/schema v1.2.0
 	github.com/json-iterator/go v1.1.11
 	github.com/stretchr/testify v1.3.0
 	github.com/unknwon/com v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/go-chi/chi v1.5.1/go.mod h1:REp24E+25iKvxgeTfHmdUoL5x15kBiDBlnIl5bCwe
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=


### PR DESCRIPTION
Remove ctx.Req.Request.Body.Close(). Go handles this automatically.
https://stackoverflow.com/questions/42525499/where-to-put-defer-req-body-close

Signed-off-by: Tamal Saha <tamal@appscode.com>